### PR TITLE
Add start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "jest",
     "watch": "jest --watch",
     "production": "webpack -p",
-    "serve": "webpack-dev-server --content-base dist/"
+    "start": "webpack-dev-server --content-base dist/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Using a `start` scripts allows `npm start`, rather than the longer
`npm run serve` to start up the dev server