### PR TITLE
Allow replacement of operator

### DIFF
--- a/src/state/statestore.spec.js
+++ b/src/state/statestore.spec.js
@@ -8,10 +8,6 @@ describe('reducer', () => {
       expect(reducer().tokens).toEqual([])
     })
 
-    it('initialises with the `canAddOperator` property set to false', () => {
-      expect(reducer().canAddOperator).toBe(false)
-    })
-
     it('initialises with a null result', () => {
       expect(reducer().result).toBe(null)
     })
@@ -24,10 +20,6 @@ describe('reducer', () => {
     }
 
     describe('when the token list is empty', () => {
-      it('sets the `canAddOperator` property to true', () => {
-        expect(reducer(undefined, action).canAddOperator).toBe(true)
-      })
-
       it('adds the number to the token list', () => {
         expect(reducer(undefined, action).tokens).toEqual([0])
       })
@@ -37,10 +29,6 @@ describe('reducer', () => {
       const start = reducer(undefined, {
         type: 'APPEND_NUMBER',
         value: 1
-      })
-
-      it('sets the `canAddOperator` property to true', () => {
-        expect(reducer(start, action).canAddOperator).toBe(true)
       })
 
       it('appends the number to the existing number', () => {
@@ -56,10 +44,6 @@ describe('reducer', () => {
       const second = reducer(first, {
         type: 'APPEND_OPERATOR',
         value: '+'
-      })
-
-      it('sets the `canAddOperator` property to true', () => {
-        expect(reducer(second, action).canAddOperator).toBe(true)
       })
 
       it('adds the number to the token list', () => {
@@ -84,10 +68,6 @@ describe('reducer', () => {
       const start = reducer(undefined, {
         type: 'APPEND_NUMBER',
         value: 0
-      })
-
-      it('sets the `canAddOperator` property to false', () => {
-        expect(reducer(start, action).canAddOperator).toBe(false)
       })
 
       it('adds the operator to the token list', () => {
@@ -117,14 +97,12 @@ describe('reducer', () => {
     it('does nothing when the store is empty', () => {
       const state = reducer(undefined, del)
       expect(state.tokens).toEqual([])
-      expect(state.canAddOperator).toBeFalsy()
     })
 
     it('will remove a single number', () => {
       const first = reducer(undefined, {type: 'APPEND_NUMBER', value: 1})
       const state = reducer(first, del)
       expect(state.tokens).toEqual([])
-      expect(state.canAddOperator).toBeFalsy()
     })
 
     it('will remove the last digit of a number', () => {
@@ -132,7 +110,6 @@ describe('reducer', () => {
       const second = reducer(first, {type: 'APPEND_NUMBER', value: 3})
       const state = reducer(second, del)
       expect(state.tokens).toEqual([2])
-      expect(state.canAddOperator).toBeTruthy()
     })
 
     it('will remove an operator', () => {
@@ -140,7 +117,6 @@ describe('reducer', () => {
       const second = reducer(first, {type: 'APPEND_OPERATOR', value: '+'})
       const state = reducer(second, del)
       expect(state.tokens).toEqual([4])
-      expect(state.canAddOperator).toBeTruthy()
     })
   })
 
@@ -150,7 +126,6 @@ describe('reducer', () => {
     it('does nothing when the store is empty', () => {
       const state = reducer(undefined, del)
       expect(state.tokens).toEqual([])
-      expect(state.canAddOperator).toBeFalsy()
     })
 
     it('will remove all digits', () => {
@@ -158,7 +133,6 @@ describe('reducer', () => {
       const second = reducer(first, {type: 'APPEND_NUMBER', value: 3})
       const state = reducer(second, del)
       expect(state.tokens).toEqual([])
-      expect(state.canAddOperator).toBeFalsy()
     })
   })
 })
@@ -167,19 +141,17 @@ describe('store', () => {
   it('returns the initial state', () => {
     expect(store.getState()).toEqual({
       tokens: [],
-      canAddOperator: false,
       result: null
     })
   })
 
-  it('processes a first action', () => {
+  it('processes an action', () => {
     store.dispatch({
       type: 'APPEND_NUMBER',
       value: 2
     })
     expect(store.getState()).toEqual({
       tokens: [2],
-      canAddOperator: true,
       result: 2
     })
   })


### PR DESCRIPTION
- If there is already an operator, then adding another one should replace the existing one
- Refactored the state to remove the `canAddOperator` property which was only used internally