### PR TITLE
Add more TypeStyle

### DIFF
--- a/src/view/button.js
+++ b/src/view/button.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {Token} from './token'
+import {displayStyle} from './style'
 
 export function Button ({value, onSubmit}) {
   return <td onClick={onSubmit}><Token value={value} /></td>
@@ -35,7 +36,7 @@ export function Buttons ({dispatcher}) {
   }
 
   return (
-    <div className='display'>
+    <div className={displayStyle}>
       <table>
         <tbody>
           <tr>

--- a/src/view/display.js
+++ b/src/view/display.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {Token} from './token'
+import {lineStyle, displayStyle} from './style'
 
 export function Display ({expression, result}) {
   let line = [].concat(expression)
@@ -10,8 +11,8 @@ export function Display ({expression, result}) {
 
   const tokens = line.map((value, index) => <Token value={value} key={index} />)
   return (
-    <div className='display'>
-      <div className='line'>{tokens}</div>
+    <div className={displayStyle}>
+      <div className={lineStyle}>{tokens}</div>
     </div>
   )
 }

--- a/src/view/style.js
+++ b/src/view/style.js
@@ -1,0 +1,28 @@
+import {style} from 'typestyle'
+
+export const lineStyle = style({
+  display: 'flex',
+  padding: '10px 20px',
+  height: '45px'
+})
+
+export const displayStyle = style({
+  width: '600px',
+  maxWidth: '90vw',
+  backgroundColor: 'whitesmoke',
+  boxShadow: '3px 3px 3px lightgray',
+  margin: '20px'
+})
+
+const tokenCommon = {
+  fontSize: '20px',
+  padding: '10px 16px',
+  margin: '2px',
+  borderRadius: '25px',
+  textAlign: 'center'
+}
+
+export const numberStyle = style(tokenCommon, {background: 'paleturquoise'})
+export const operatorStyle = style(tokenCommon, {background: 'lightblue'})
+export const equalsStyle = style(tokenCommon, {background: 'palegreen'})
+export const clearStyle = style(tokenCommon, {background: 'pink'})

--- a/src/view/token.js
+++ b/src/view/token.js
@@ -1,36 +1,20 @@
 import React from 'react'
-import {style} from 'typestyle'
-
+import {numberStyle, operatorStyle, equalsStyle, clearStyle} from './style'
 export function Token ({value}) {
   return <div className={tokenClassName(value)}>{tokenValue(value)}</div>
 }
 
-const commonStyle = {
-  'font-size': '20px',
-  'padding': '10px 16px',
-  'margin': '2px',
-  'border-radius': '25px',
-  'text-align': 'center'
-}
-
-export const tokenStyle = {
-  number: style(commonStyle, {background: 'paleturquoise'}),
-  operator: style(commonStyle, {background: 'lightblue'}),
-  equals: style(commonStyle, {background: 'palegreen'}),
-  clear: style(commonStyle, {background: 'pink'})
-}
-
 function tokenClassName (value) {
   if (typeof value === 'number') {
-    return tokenStyle.number
+    return numberStyle
   } else if (value === '=') {
-    return tokenStyle.equals
+    return equalsStyle
   } else if (value === 'C') {
-    return tokenStyle.clear
+    return clearStyle
   } else if (value === 'AC') {
-    return tokenStyle.clear
+    return clearStyle
   } else {
-    return tokenStyle.operator
+    return operatorStyle
   }
 }
 

--- a/src/view/token.spec.js
+++ b/src/view/token.spec.js
@@ -1,55 +1,56 @@
 /* eslint-env jest */
 import React from 'react'
 import {shallow} from 'enzyme'
-import {Token, tokenStyle} from './token'
+import {Token} from './token'
+import {numberStyle, operatorStyle, equalsStyle, clearStyle} from './style'
 
 describe('Token', () => {
   it('can display a number', () => {
     const wrapper = shallow(<Token value={5} />)
     const div = wrapper.find('div')
     expect(div.text()).toBe('5')
-    expect(div.hasClass(tokenStyle.number)).toBeTruthy()
+    expect(div.hasClass(numberStyle)).toBeTruthy()
   })
 
   it('can display an operator', () => {
     const wrapper = shallow(<Token value='+' />)
     const div = wrapper.find('div')
     expect(div.text()).toBe('+')
-    expect(div.hasClass(tokenStyle.operator)).toBeTruthy()
+    expect(div.hasClass(operatorStyle)).toBeTruthy()
   })
 
   it('can display an equals sign', () => {
     const wrapper = shallow(<Token value='=' />)
     const div = wrapper.find('div')
     expect(div.text()).toBe('=')
-    expect(div.hasClass(tokenStyle.equals)).toBeTruthy()
+    expect(div.hasClass(equalsStyle)).toBeTruthy()
   })
 
   it('displays a division sign', () => {
     const wrapper = shallow(<Token value='/' />)
     const div = wrapper.find('div')
     expect(div.text()).toBe('\u00F7')
-    expect(div.hasClass(tokenStyle.operator)).toBeTruthy()
+    expect(div.hasClass(operatorStyle)).toBeTruthy()
   })
 
   it('displays a multiplication sign', () => {
     const wrapper = shallow(<Token value='*' />)
     const div = wrapper.find('div')
     expect(div.text()).toBe('x')
-    expect(div.hasClass(tokenStyle.operator)).toBeTruthy()
+    expect(div.hasClass(operatorStyle)).toBeTruthy()
   })
 
   it('can display an Clear sign', () => {
     const wrapper = shallow(<Token value='C' />)
     const div = wrapper.find('div')
     expect(div.text()).toBe('C')
-    expect(div.hasClass(tokenStyle.clear)).toBeTruthy()
+    expect(div.hasClass(clearStyle)).toBeTruthy()
   })
 
   it('can display an Clear All sign', () => {
     const wrapper = shallow(<Token value='AC' />)
     const div = wrapper.find('div')
     expect(div.text()).toBe('AC')
-    expect(div.hasClass(tokenStyle.clear)).toBeTruthy()
+    expect(div.hasClass(clearStyle)).toBeTruthy()
   })
 })

--- a/web/style.css
+++ b/web/style.css
@@ -9,23 +9,9 @@ body {
   flex-direction: column;
 }
 
-.display {
-  width: 600px;
-  max-width: 90vw;
-  background-color: whitesmoke;
-  box-shadow: 3px 3px 3px lightgray;
-  margin: 20px;
-}
-
 header {
   font-size: 30px;
   text-align: center;
   margin-top: 20px;
   margin-bottom: 15px;
-}
-
-.line {
-  display: flex;
-  padding: 10px 20px;
-  height: 45px;
 }


### PR DESCRIPTION
- Create a common `style.js` which exports styles
- Use camelCase style names, e.g. `maxWidth` in preference to `max-width` (which has to be quoted)