### PR TITLE
Redux store should contain only POJOs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "react"]
+  "presets": ["es2015", "react"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "babel-jest": "^20.0.3",
     "babel-loader": "^7.0.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "big.js": "^3.1.3",

--- a/src/evaluator/evaluator.spec.js
+++ b/src/evaluator/evaluator.spec.js
@@ -1,6 +1,20 @@
 /* eslint-env jest */
 
-import {evaluate, number, operator} from '../evaluator/evaluator.js'
+import evaluate from '../evaluator/evaluator.js'
+
+const number = value => {
+  return {
+    type: 'number',
+    value: value.toString()
+  }
+}
+
+const operator = value => {
+  return {
+    type: 'operator',
+    value: value
+  }
+}
 
 describe('evaluator', () => {
   describe('invalid expressions', () => {
@@ -35,6 +49,15 @@ describe('evaluator', () => {
           operator('+')
         ])
       }).toThrowError(/Found end, but expected one of:/)
+    })
+
+    it('throws an error for an unknown operator', () => {
+      expect(() => {
+        evaluate([
+          number(7),
+          operator('&')
+        ])
+      }).toThrowError(/invalid operator: &/)
     })
   })
 
@@ -197,40 +220,6 @@ describe('evaluator', () => {
         operator('-'),
         number(1)
       ])).toBe(9)
-    })
-  })
-
-  describe('tokens', () => {
-    describe('number', () => {
-      describe('appending', () => {
-        it('performs string concatenation for a single digit number', () => {
-          const n = number(1).append(2)
-          expect(n.resolve().toString()).toBe('12')
-        })
-
-        it('performs string concatenation for a multi digit number', () => {
-          const n = number(64564).append(9)
-          expect(n.resolve().toString()).toBe('645649')
-        })
-      })
-
-      describe('removing', () => {
-        it('removes the last digit from a multi digit number', () => {
-          const n = number(4573258).remove()
-          expect(n.resolve().toString()).toBe('457325')
-        })
-
-        it('returns undefined for a single digit number', () => {
-          const n = number(4).remove()
-          expect(n).toBeUndefined()
-        })
-      })
-    })
-
-    describe('operator', () => {
-      it('will not create an invalid operator', () => {
-        expect(() => operator('foo')).toThrow(/invalid operator: foo/)
-      })
     })
   })
 })

--- a/src/evaluator/tokens.js
+++ b/src/evaluator/tokens.js
@@ -1,0 +1,20 @@
+export function operator (value) {
+  const type = 'operator'
+  return {type, value}
+}
+
+export function appendDigit (initial, addition) {
+  const type = 'number'
+  const value = (initial && typeof initial.value === 'string' ? initial.value : '') + addition
+  return {type, value}
+}
+
+export function removeDigit (initial) {
+  const type = 'number'
+  if (initial && typeof initial.value === 'string' && initial.value.length > 1) {
+    const value = initial.value.slice(0, initial.value.length - 1)
+    return {type, value}
+  } else {
+    return undefined
+  }
+}

--- a/src/evaluator/tokens.spec.js
+++ b/src/evaluator/tokens.spec.js
@@ -1,0 +1,68 @@
+/* eslint-env jest */
+
+import * as tokens from './tokens'
+
+describe('token helpers', () => {
+  describe('operators', () => {
+    it('can create an operator token', () => {
+      const o = tokens.operator('+')
+      expect(o.type).toBe('operator')
+      expect(o.value).toBe('+')
+    })
+
+    it('does not validate the operator type', () => {
+      const o = tokens.operator('foo') // Invalid!
+      expect(o.type).toBe('operator')
+      expect(o.value).toBe('foo')
+    })
+  })
+
+  describe('appending to numbers', () => {
+    it('creates a number when appending to `undefined`', () => {
+      const n = tokens.appendDigit(undefined, 1)
+      expect(n.type).toBe('number')
+      expect(n.value).toBe('1') // String
+    })
+
+    it('appends to an existing number', () => {
+      const i = tokens.appendDigit(undefined, 1)
+      const n = tokens.appendDigit(i, 2)
+      expect(n.type).toBe('number')
+      expect(n.value).toBe('12') // String
+    })
+
+    it('can take a string', () => {
+      const n = tokens.appendDigit(undefined, '4')
+      expect(n.type).toBe('number')
+      expect(n.value).toBe('4') // String
+    })
+
+    it('appends a string to an existing number', () => {
+      const i = tokens.appendDigit(undefined, '8')
+      const n = tokens.appendDigit(i, '1')
+      expect(n.type).toBe('number')
+      expect(n.value).toBe('81') // String
+    })
+  })
+
+  describe('removing from numbers', () => {
+    it('removes a digit from a multi-digit number', () => {
+      const initial = {
+        type: 'number',
+        value: '123'
+      }
+      const n = tokens.removeDigit(initial)
+      expect(n.type).toBe('number')
+      expect(n.value).toBe('12')
+    })
+
+    it('returns undefined when there are no digits left', () => {
+      const initial = {
+        type: 'number',
+        value: '5'
+      }
+      const n = tokens.removeDigit(initial)
+      expect(n).toBeUndefined()
+    })
+  })
+})

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,7 +1,8 @@
 import {createStore as createReduxStore, combineReducers} from 'redux'
 import bindSelectors from 'redux-bind-selectors'
 import {createSelector} from 'reselect'
-import {evaluate, number, operator} from '../evaluator/evaluator.js'
+import evaluate from '../evaluator/evaluator.js'
+import * as tokens from '../evaluator/tokens'
 
 function tokensReducer (tokensIn = [], action) {
   const tail = tokensIn[tokensIn.length - 1]
@@ -12,18 +13,19 @@ function tokensReducer (tokensIn = [], action) {
     case 'APPEND_NUMBER':
       if (tokensIn.length > 0 && tail.type === 'number') {
         // Append to existing number
-        tokensOut = [...head, tail.append(action.value)]
+        tokensOut = [...head, tokens.appendDigit(tail, action.value)]
       } else {
-        tokensOut = [...tokensIn, number(action.value)]
+        // Add a new number token
+        tokensOut = [...tokensIn, tokens.appendDigit(undefined, action.value)]
       }
       break
     case 'APPEND_OPERATOR':
       if (tokensIn.length) { // Can't add operator as first token
         if (tail.type === 'number') {
-          tokensOut = [...tokensIn, operator(action.value)]
+          tokensOut = [...tokensIn, tokens.operator(action.value)]
         } else {
           // Replace existing operator
-          tokensOut = [...head, operator(action.value)]
+          tokensOut = [...head, tokens.operator(action.value)]
         }
       }
       break
@@ -32,7 +34,7 @@ function tokensReducer (tokensIn = [], action) {
         if (tail.type === 'operator') {
           tokensOut = head
         } else {
-          const newNumber = tail.remove()
+          const newNumber = tokens.removeDigit(tail)
           if (newNumber) {
             tokensOut = [...head, newNumber]
           } else {

--- a/src/state/store.spec.js
+++ b/src/state/store.spec.js
@@ -29,7 +29,7 @@ describe('store', () => {
         store.dispatch(action)
         const result = store.getState().tokens[0]
         expect(result.type).toBe('number')
-        expect(result.resolve().toString()).toBe('0')
+        expect(result.value).toBe('0')
       })
     })
 
@@ -44,7 +44,7 @@ describe('store', () => {
         store.dispatch(action)
         const token = store.getState().tokens[0]
         expect(token.type).toBe('number')
-        expect(token.resolve().toString()).toBe('10')
+        expect(token.value).toBe('10')
       })
     })
 
@@ -64,10 +64,10 @@ describe('store', () => {
         store.dispatch(first)
         const tokens = store.getState().tokens
         expect(tokens[0].type).toBe('number')
-        expect(tokens[0].resolve().toString()).toBe('0')
+        expect(tokens[0].value).toBe('0')
         expect(tokens[1].type).toBe('operator')
         expect(tokens[2].type).toBe('number')
-        expect(tokens[2].resolve().toString()).toBe('0')
+        expect(tokens[2].value).toBe('0')
       })
     })
   })
@@ -142,7 +142,7 @@ describe('store', () => {
       store.dispatch({type: 'APPEND_NUMBER', value: 3})
       store.dispatch(del)
       const state = store.getState()
-      expect(state.tokens[0].resolve().toString()).toBe('2')
+      expect(state.tokens[0].value).toBe('2')
     })
 
     it('will remove an operator', () => {

--- a/src/view/result.js
+++ b/src/view/result.js
@@ -5,7 +5,6 @@ import {style} from 'typestyle'
 
 export const resultStyle = style({
   display: 'flex',
-  direction: 'rtl',
   padding: '10px 20px',
   height: '45px'
 })


### PR DESCRIPTION
- The redux store should contain only plain old JavaScript/JSON objects
- currently some of the objects have functions, and this is bad practice
- solution is to have helper functions that do the same thing, but are not part of the object
- also fixed a rendering order bug that was making `78` render as `87`